### PR TITLE
perf: optimize span count metric gathering

### DIFF
--- a/internal/sql/query.sql.go
+++ b/internal/sql/query.sql.go
@@ -187,7 +187,7 @@ func (q *Queries) GetServices(ctx context.Context) ([]string, error) {
 
 const getSpansCount = `-- name: GetSpansCount :one
 
-SELECT COUNT(*) FROM spans
+SELECT n_live_tup FROM pg_stat_user_tables WHERE relname = 'spans'
 `
 
 func (q *Queries) GetSpansCount(ctx context.Context) (int64, error) {

--- a/internal/sql/query.sql.go
+++ b/internal/sql/query.sql.go
@@ -187,7 +187,17 @@ func (q *Queries) GetServices(ctx context.Context) ([]string, error) {
 
 const getSpansCount = `-- name: GetSpansCount :one
 
-SELECT n_live_tup FROM pg_stat_user_tables WHERE relname = 'spans'
+WITH span_tables AS (
+    SELECT inhrelid::regclass::text AS relname
+    FROM pg_catalog.pg_class
+        JOIN pg_catalog.pg_inherits ON inhparent = oid
+    WHERE relname = 'spans'
+    UNION
+    SELECT 'spans'
+)
+SELECT sum(n_live_tup)
+FROM pg_stat_user_tables
+    JOIN span_tables USING (relname) 
 `
 
 func (q *Queries) GetSpansCount(ctx context.Context) (int64, error) {
@@ -199,7 +209,16 @@ func (q *Queries) GetSpansCount(ctx context.Context) (int64, error) {
 
 const getSpansDiskSize = `-- name: GetSpansDiskSize :one
 
-SELECT pg_total_relation_size('spans')
+WITH span_tables AS (
+    SELECT inhrelid::regclass::text AS relname
+    FROM pg_catalog.pg_class
+        JOIN pg_catalog.pg_inherits ON inhparent = oid
+    WHERE relname = 'spans'
+    UNION
+    SELECT 'spans'
+)
+SELECT sum(pg_total_relation_size(relname))
+FROM span_tables
 `
 
 func (q *Queries) GetSpansDiskSize(ctx context.Context) (int64, error) {


### PR DESCRIPTION
## Description

When analyzing the database performance I found out that one query was stuck for several minutes. I trace it back to the span count query that is used to return the jaeger_postgresql_spans_count metric. 

This can easily be visualized looking at the metric, while stuck the span count is not updated:

![image](https://github.com/user-attachments/assets/2b463286-cbd0-4c21-b198-52ec5673954d)

## Proposal

instead of querying the database for the exact count of the span table which is rather costly do a postgres stat lookup which is quite close and extremely fast.

## Validation

With the new version the metric is smooth

![image](https://github.com/user-attachments/assets/dcd83946-15eb-440f-913f-95599e87d374)
